### PR TITLE
Reset the data in `mi` to the initial state

### DIFF
--- a/multiindex/tests/test_multiindex.py
+++ b/multiindex/tests/test_multiindex.py
@@ -55,6 +55,7 @@ def test_insert_overwrite(mi, emp_seq):
     mi.insert(Employee('Razor', 'Topaz', 8732), overwrite=True)
     assert mi.get('emp_id', 8732).last_name == 'Topaz'
     assert mi.get('first_name', 'Razor').emp_id == 8732
+    mi.insert(emp_seq[0], overwrite=True)
 
 
 def test_modify(mi):


### PR DESCRIPTION
The PR aims to improve the reliability of the test `test_insert_overwrite` by resetting the data in object `mi` to the initial state by calling `insert` to insert the original tuple.

The test can fail in the following way if `im` is not in the initial state:
```
>       assert emp_seq[0] == mi.get('first_name', 'Steve')
E       AssertionError: assert <multiindex.tests.test_multiindex.Employee object at 0x7f48a4106f40> == <multiindex.tests.test_multiindex.Employee object at 0x7f48a411a100>
E        +  where <multiindex.tests.test_multiindex.Employee object at 0x7f48a411a100> = <bound method MultiIndexContainer.get of <multiindex.multiindex.MultiIndexContainer object at 0x7f48a411ae80>>('first_name', 'Steve')
E        +    where <bound method MultiIndexContainer.get of <multiindex.multiindex.MultiIndexContainer object at 0x7f48a411ae80>> = <multiindex.multiindex.MultiIndexContainer object at 0x7f48a411ae80>.get
```