### PR TITLE
Reset the data in `mi` to the initial state

### DIFF
--- a/multiindex/tests/test_multiindex.py
+++ b/multiindex/tests/test_multiindex.py
@@ -67,8 +67,8 @@ def test_modify(mi):
 
 
 def test_remove(mi):
-    mi.remove('emp_id', 666)
-    assert mi.get('emp_id', 666) is None
+    mi.remove('emp_id', 786)
+    assert mi.get('emp_id', 786) is None
 
 
 def test_get_by(mi):

--- a/multiindex/tests/test_multiindex.py
+++ b/multiindex/tests/test_multiindex.py
@@ -63,6 +63,7 @@ def test_modify(mi):
     assert mi.get('emp_id', 666).last_name == 'Austin'
     assert mi.get('first_name', 'Steve').emp_id == 666
     assert mi.get('last_name', 'Austin').emp_id == 666
+    mi.modify('emp_id', 666, 786)
 
 
 def test_remove(mi):


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_modify` by resetting the data in `mi` to the initial state by calling method `mi.modify`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 multiindex/tests/test_multiindex.py::test_modify`:

```
    def test_modify(mi):
>       mi.modify('emp_id', 786, 666)
...
>       setattr(obj, indexed_by, new_value)
E       AttributeError: 'NoneType' object has no attribute 'emp_id'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
