### PR TITLE
Avoiding order dependency by altering `pytest.fixture` scope to `function`

### DIFF
--- a/multiindex/tests/test_multiindex_hashed_non_unique.py
+++ b/multiindex/tests/test_multiindex_hashed_non_unique.py
@@ -13,7 +13,7 @@ class Potus(object):
         return '{} {}, {}'.format(self.first_name, self.last_name, self.assumed_ofc_at)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def potus_seq():
     seq = [Potus('George', 'Washington', 57),
            Potus('Thomas', 'Jefferson', 58),
@@ -25,7 +25,7 @@ def potus_seq():
     return seq
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def mi(potus_seq):
     mi = MultiIndexContainer(HashedNonUnique('first_name'),
                              HashedNonUnique('last_name'),


### PR DESCRIPTION
This PR aims to improve test reliability of tests in `test_multiindex.py` by avoiding order dependency by altering `pytest.fixture` scope to `function`.

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest multiindex/tests/test_multiindex_hashed_non_unique.py --count=2`
:

```
    def test_remove(mi):
        mi.remove('first_name', 'George')
>       assert len(mi.get('first_name', 'George')) == 1
E       AssertionError: assert 0 == 1
E        +  where 0 = len([])
E        +    where [] = <bound method MultiIndexContainer.get of <multiindex.multiindex.MultiIndexContainer object at 0x7f3aef5d51c0>>('first_name', 'George')
E        +      where <bound method MultiIndexContainer.get of <multiindex.multiindex.MultiIndexContainer object at 0x7f3aef5d51c0>> = <multiindex.multiindex.MultiIndexContainer object at 0x7f3aef5d51c0>.get
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
